### PR TITLE
Rename WebApp workflow

### DIFF
--- a/.github/workflows/webapp.yml
+++ b/.github/workflows/webapp.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Web Application
 
 on:
   push:


### PR DESCRIPTION
Renamed _CI_ workflow to _Web Application_.
There is separate  _Device Software_ workflow, so no need to use general _CI_ name for the only one workflow.